### PR TITLE
Check PHP API version in build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ edition = "2018"
 
 [build-dependencies]
 bindgen = "0.53.1"
+regex = "1"


### PR DESCRIPTION
Ensure that the user is compiling with a supported version
of PHP.

Closes #10 